### PR TITLE
Moved tag parsing to the intrinsics package

### DIFF
--- a/goformation_test.go
+++ b/goformation_test.go
@@ -9,8 +9,6 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 )
 
-
-
 var _ = Describe("Goformation", func() {
 
 	Context("with a Serverless function matching 2016-10-31 specification", func() {
@@ -140,7 +138,7 @@ var _ = Describe("Goformation", func() {
 				Name: "example.com",
 			}
 
-			result, err := goformation.Parse(template)
+			result, err := goformation.ParseJSON(template)
 			It("should marshal to Go structs successfully", func() {
 				Expect(err).To(BeNil())
 			})
@@ -235,22 +233,22 @@ var _ = Describe("Goformation", func() {
 	// Commented out until we have support for YAML tag intrinsic functions (e.g. !Sub)
 	Context("with a YAML template containing intrinsic tags (e.g. !Sub)", func() {
 
-	 	template, err := goformation.Open("test/yaml/yaml-intrinsic-tags.yaml")
-	 	It("should successfully validate the SAM template", func() {
-	 		Expect(err).To(BeNil())
-	 		Expect(template).ShouldNot(PointTo(BeNil()))
-	 	})
+		template, err := goformation.Open("test/yaml/yaml-intrinsic-tags.yaml")
+		It("should successfully validate the SAM template", func() {
+			Expect(err).To(BeNil())
+			Expect(template).ShouldNot(PointTo(BeNil()))
+		})
 
-	 	function, err := template.GetAWSServerlessFunctionWithName("IntrinsicFunctionTest")
-	 	It("should have a function named 'IntrinsicFunctionTest'", func() {
-	 		Expect(function).To(Not(BeNil()))
-	 		Expect(err).To(BeNil())
-	 	})
+		function, err := template.GetAWSServerlessFunctionWithName("IntrinsicFunctionTest")
+		It("should have a function named 'IntrinsicFunctionTest'", func() {
+			Expect(function).To(Not(BeNil()))
+			Expect(err).To(BeNil())
+		})
 
-	 	It("it should have the correct values", func() {
-	 		Expect(function.Runtime).To(Equal(""))
-	 		Expect(function.Timeout).To(Equal(10))
-	 	})
+		It("it should have the correct values", func() {
+			Expect(function.Runtime).To(Equal(""))
+			Expect(function.Timeout).To(Equal(10))
+		})
 
 	})
 

--- a/intrinsics/intrinsics_test.go
+++ b/intrinsics/intrinsics_test.go
@@ -14,7 +14,7 @@ var _ = Describe("AWS CloudFormation intrinsic function processing", func() {
 
 	Context("with a template that contains invalid JSON", func() {
 		input := `{`
-		processed, err := Process([]byte(input), nil)
+		processed, err := ProcessJSON([]byte(input), nil)
 		It("should fail to process the template", func() {
 			Expect(processed).To(BeNil())
 			Expect(err).ToNot(BeNil())
@@ -24,7 +24,7 @@ var _ = Describe("AWS CloudFormation intrinsic function processing", func() {
 	Context("with a template that contains a 'Ref' intrinsic function", func() {
 
 		input := `{"Parameters":{"FunctionTimeout":{"Type":"Number","Default":120}},"Resources":{"MyServerlessFunction":{"Type":"AWS::Serverless::Function","Properties":{"Runtime":"nodejs6.10","Timeout":{"Ref":"FunctionTimeout"}}}}}`
-		processed, err := Process([]byte(input), nil)
+		processed, err := ProcessJSON([]byte(input), nil)
 		It("should successfully process the template", func() {
 			Expect(processed).ShouldNot(BeNil())
 			Expect(err).Should(BeNil())
@@ -52,7 +52,7 @@ var _ = Describe("AWS CloudFormation intrinsic function processing", func() {
 	Context("with a template that contains a 'Ref' intrinsic function with a 'Fn::Join' inside it", func() {
 
 		input := `{"Parameters":{"FunctionTimeout":{"Type":"Number","Default":120}},"Resources":{"MyServerlessFunction":{"Type":"AWS::Serverless::Function","Properties":{"Runtime":"nodejs6.10","Timeout":{"Ref":{"Fn::Join":["Function","Timeout"]}}}}}}`
-		processed, err := Process([]byte(input), nil)
+		processed, err := ProcessJSON([]byte(input), nil)
 		It("should successfully process the template", func() {
 			Expect(processed).ShouldNot(BeNil())
 			Expect(err).Should(BeNil())
@@ -77,33 +77,42 @@ var _ = Describe("AWS CloudFormation intrinsic function processing", func() {
 
 	})
 
-	// pmaddox@ 2017-08-17:
-	// Commented out until we have support for YAML tag intrinsic functions (e.g. !Sub)
-	//Context("with a YAML template that contains intrinsic functions in tag form", func() {
+	// Context("with a YAML template that contains intrinsic functions in tag form", func() {
 
-	// t := "AWSTemplateFormatVersion: '2010-09-09'\n"
-	// t += "Transform: AWS::Serverless-2016-10-31\n"
-	// t += "Description: SAM template for testing intrinsic functions with YAML tags\n"
-	// t += "Resources:\n"
-	// t += "  CodeUriWithS3LocationSpecifiedAsString:\n"
-	// t += "    Type: AWS::Serverless::Function\n"
-	// t += "    Properties:\n"
-	// t += "      Runtime: !Sub test-${runtime}\n"
-	// t += "      Timeout: !Ref ThisWontResolve\n"
+	// 	t := "AWSTemplateFormatVersion: '2010-09-09'\n"
+	// 	t += "Transform: AWS::Serverless-2016-10-31\n"
+	// 	t += "Description: SAM template for testing intrinsic functions with YAML tags\n"
+	// 	t += "Resources:\n"
+	// 	t += "  CodeUriWithS3LocationSpecifiedAsString:\n"
+	// 	t += "    Type: AWS::Serverless::Function\n"
+	// 	t += "    Properties:\n"
+	// 	t += "      Runtime: !Sub test-${runtime}\n"
+	// 	t += "      Timeout: !Ref ThisWontResolve\n"
 
-	// data, err := yaml.YAMLToJSON([]byte(t))
-	// It("should successfully convert YAML to JSON", func() {
-	// 	Expect(data).ShouldNot(BeNil())
-	// 	Expect(err).Should(BeNil())
+	// 	processed, err := ProcessYAML([]byte(t), nil)
+	// 	It("should successfully process the template", func() {
+	// 		Expect(processed).ShouldNot(BeNil())
+	// 		Expect(err).Should(BeNil())
+	// 	})
+
+	// 	var result interface{}
+	// 	err = json.Unmarshal(processed, &result)
+	// 	It("should be valid JSON, and marshal to a Go type", func() {
+	// 		Expect(processed).ToNot(BeNil())
+	// 		Expect(err).To(BeNil())
+	// 	})
+
+	// 	template := result.(map[string]interface{})
+	// 	resources := template["Resources"].(map[string]interface{})
+	// 	resource := resources["CodeUriWithS3LocationSpecifiedAsString"].(map[string]interface{})
+	// 	properties := resource["Properties"].(map[string]interface{})
+
+	// 	It("should have the correct values", func() {
+	// 		Expect(properties["Timeout"]).To(Equal(0))
+	// 		Expect(properties["Runtime"]).To(Equal("test-"))
+	// 	})
+
 	// })
-
-	// processed, err := Process(data, nil)
-	// It("should successfully process the template", func() {
-	// 	Expect(processed).ShouldNot(BeNil())
-	// 	Expect(err).Should(BeNil())
-	// })
-
-	//}
 
 	Context("with a template that contains primitives, intrinsics, and nested intrinsics", func() {
 
@@ -144,7 +153,7 @@ var _ = Describe("AWS CloudFormation intrinsic function processing", func() {
 
 		Context("with no processor options", func() {
 
-			processed, err := Process([]byte(template), nil)
+			processed, err := ProcessJSON([]byte(template), nil)
 			It("should successfully process the template", func() {
 				Expect(processed).ShouldNot(BeNil())
 				Expect(err).Should(BeNil())
@@ -249,7 +258,7 @@ var _ = Describe("AWS CloudFormation intrinsic function processing", func() {
 				},
 			}
 
-			processed, err := Process([]byte(template), opts)
+			processed, err := ProcessJSON([]byte(template), opts)
 			It("should successfully process the template", func() {
 				Expect(processed).ShouldNot(BeNil())
 				Expect(err).Should(BeNil())

--- a/intrinsics/ref.go
+++ b/intrinsics/ref.go
@@ -53,6 +53,6 @@ func Ref(name string, input interface{}, template interface{}) interface{} {
 
 	}
 
-	return input
+	return nil
 
 }

--- a/intrinsics/tags.go
+++ b/intrinsics/tags.go
@@ -1,0 +1,45 @@
+package intrinsics
+
+import (
+	"reflect"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+var allTags = []string{"Ref", "GetAtt", "Base64", "FindInMap", "GetAZs",
+	"ImportValue", "Join", "Select", "Split", "Sub",
+}
+
+type tagUnmarshalerType struct {
+}
+
+func (t *tagUnmarshalerType) UnmarshalYAMLTag(tag string, fieldValue reflect.Value) reflect.Value {
+
+	prefix := "Fn::"
+	if tag == "Ref" || tag == "Condition" {
+		prefix = ""
+	}
+
+	tag = prefix + tag
+
+	output := reflect.ValueOf(make(map[string]interface{}))
+	key := reflect.ValueOf(tag)
+
+	output.SetMapIndex(key, fieldValue)
+
+	return output
+}
+
+var tagUnmarshaller = &tagUnmarshalerType{}
+
+func registerTagMarshallers() {
+	for _, tag := range allTags {
+		yaml.RegisterTagUnmarshaler("!"+tag, tagUnmarshaller)
+	}
+}
+
+func unregisterTagMarshallers() {
+	for _, tag := range allTags {
+		yaml.RegisterTagUnmarshaler("!"+tag, tagUnmarshaller)
+	}
+}


### PR DESCRIPTION
I think this makes for a neater API if we move the intrinsic tag handling to the intrinsics package. 

It also means all YAML->JSON conversion can be done in the intrinsics package too.

```go
intrinsics.ProcessYAML(data, opts)
intrinsics.ProcessJSON(data, opts)
```